### PR TITLE
Fix a few minor issues in docker implementation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -45,11 +45,12 @@ docker-compose -p spire -f docker-compose.server.yml up -d
 
 ## Trust the Anthem SPIRE Server
 
-run `scripts/2-trust-anthem.sh` to pull the AnthemAI certificate authority and add it to your spire server.
+Run `chmod +x ./scripts/2-trust-anthem-trust-bundle.sh && ./scripts/2-trust-anthem-trust-bundle.sh` to pull the AnthemAI certificate authority and add it to your spire server.
+
 
 ## Create SPIRE SVID for envoy docker image
 
-Run `scripts/3-spire-registration.sh`, this will create a SPIRE entry/certificate for the envoy container.
+Run `chmod +x ./scripts/3-spire-registration.sh && ./scripts/3-spire-registration.sh`, this will create a SPIRE entry/certificate for the envoy container.
 
 ## Launch SPIRE Agent and Envoy
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,7 +47,6 @@ docker-compose -p spire -f docker-compose.server.yml up -d
 
 Run `chmod +x ./scripts/2-trust-anthem-trust-bundle.sh && ./scripts/2-trust-anthem-trust-bundle.sh` to pull the AnthemAI certificate authority and add it to your spire server.
 
-
 ## Create SPIRE SVID for envoy docker image
 
 Run `chmod +x ./scripts/3-spire-registration.sh && ./scripts/3-spire-registration.sh`, this will create a SPIRE entry/certificate for the envoy container.

--- a/docker/scripts/test.sh
+++ b/docker/scripts/test.sh
@@ -26,7 +26,7 @@ sleep 5
 
 docker-compose -p spire -f docker-compose.services.yml up -d
 
-docker logs -f spire_agent_1
+docker logs -f spire-agent-1
 wait
 
 cleanup

--- a/docker/templates/spire-registration.sh
+++ b/docker/templates/spire-registration.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # get cert hash
-HASH=$(cat certs/service.pem | openssl x509 -outform DER | openssl sha1)
+HASH=$(cat certs/service.pem | openssl x509 -outform DER | openssl dgst -sha1 -binary | xxd -p)
 
-docker exec -it "spire_server_1" ./bin/spire-server entry create \
+docker exec "spire-server-1" ./bin/spire-server entry create \
     -parentID "spiffe://{{ (datasource "values").internal.spire.trust_domain }}/spire/agent/x509pop/${HASH}" \
     -spiffeID "spiffe://{{ (datasource "values").internal.spire.trust_domain }}/envoy" \
     --selector docker:image_id:envoyproxy/envoy-alpine:v1.14.4 \

--- a/docker/templates/trust-anthem-trust-bundle.sh
+++ b/docker/templates/trust-anthem-trust-bundle.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 # add curl
-docker exec -it "spire_server_1" apk update
-docker exec -it "spire_server_1" apk add curl
+docker exec "spire-server-1" apk update
+docker exec "spire-server-1" apk add curl
 
 # grab trust bundle from anthem
-docker exec -it "spire_server_1" /bin/sh -c \
+docker exec "spire-server-1" /bin/sh -c \
     "curl -k https://{{ (datasource "values").anthem.spire.hostname }}:{{ (datasource "values").anthem.spire.port }} > /tmp/test.json"
 
 # add the trust bundle we downloaded to our certificate store
-docker exec -it "spire_server_1" ./bin/spire-server bundle set \
+docker exec "spire-server-1" ./bin/spire-server bundle set \
     -format spiffe \
     -id "spiffe://{{ (datasource "values").anthem.spire.trust_domain }}" \
     -path /tmp/test.json


### PR DESCRIPTION
- Fixes the certificate hash command. The previous command was producing an extraneous `(stdin)= ` at the front of the output with leads to an invalid parentID.
- Removes unnecessary interactive mode from docker commands so they work in non-interactive scenarios.
- Addresses issues with incorrect docker container names
- Updates the docker README