### PR TITLE
Add grpcurl sidecar

### DIFF
--- a/k8s/templates/hos-proxy.yaml
+++ b/k8s/templates/hos-proxy.yaml
@@ -67,10 +67,19 @@ spec:
           - |
             while true; do
               sleep 15s
-              /bin/grpcurl -plaintext localhost:5000 list
+              /bin/grpcurl -plaintext localhost:5000 list &
               echo "------------------------"
               sleep 15s
             done
+          readinessProbe:
+            exec:
+              command:
+              - /bin/grpcurl
+              - -plaintext
+              - localhost:5000
+              - list
+            initialDelaySeconds: 30
+            periodSeconds: 30
           image: fullstorydev/grpcurl:v1.8.7-alpine
       volumes:
         - name: spire-agent-socket

--- a/k8s/templates/hos-proxy.yaml
+++ b/k8s/templates/hos-proxy.yaml
@@ -58,6 +58,20 @@ spec:
           - mountPath: /run/spire/sockets
             name: spire-agent-socket
             readOnly: true
+        - name: grpcurl
+          command:
+          - /bin/sh
+          - -c
+          - --
+          args:
+          - |
+            while true; do
+              sleep 15s
+              /bin/grpcurl -plaintext localhost:5000 list
+              echo "------------------------"
+              sleep 15s
+            done
+          image: fullstorydev/grpcurl:v1.8.7-alpine
       volumes:
         - name: spire-agent-socket
           hostPath:


### PR DESCRIPTION
Tested on `hos-uat-federation`

This change adds a sidecar `grpcurl` container to the `hos-proxy` pod that lists the available API calls every 30 seconds 
